### PR TITLE
Fix broken tests and incorrect parsing of default options in Jed constructor

### DIFF
--- a/jed.js
+++ b/jed.js
@@ -98,8 +98,8 @@ in order to offer easy upgrades -- jsgettext.berlios.de
     this.options = _.extend( {}, this.defaults, options );
     this.textdomain( this.options.domain );
 
-    if ( this.options.domain && ! this.options.locale_data[ this.options.domain ] ) {
-      throw new Error('Text domain set to non-existent domain: `' + this.options.domain + '`');
+    if ( options.domain && ! this.options.locale_data[ this.options.domain ] ) {
+      throw new Error('Text domain set to non-existent domain: `' + options.domain + '`');
     }
   };
 


### PR DESCRIPTION
I see you accepted pull request #6, but commit 87731d483ae3187a038d631a6bb3b339b8cb2686 broke your tests. Even more importantly, the breakage raises the question of what the correct behavior of the Jed constructor should be! I believe that commit misunderstood your logic, and I think this pull request causes the correct behavior, but please check -- I'm not sure I correctly inferred what you want lines 101-103 to do. 

More detail:
See your "Domain" tests starting on [line 125 of the test file](https://github.com/SlexAxton/Jed/blob/master/test/tests.js#L125). On [line 137](https://github.com/SlexAxton/Jed/blob/master/test/tests.js#L137), you instantiate a Jed instance without a domain, but you pass in locale data that does not contain locale data for the default "messages" domain. So an error gets thrown. You do the same thing in your test file at [line 188](https://github.com/SlexAxton/Jed/blob/master/test/tests.js#L188), [line 300](https://github.com/SlexAxton/Jed/blob/master/test/tests.js#L300), [line 395](https://github.com/SlexAxton/Jed/blob/master/test/tests.js#L395), [line 416](https://github.com/SlexAxton/Jed/blob/master/test/tests.js#L416), [line 477](https://github.com/SlexAxton/Jed/blob/master/test/tests.js#L477), and [line 507](https://github.com/SlexAxton/Jed/blob/master/test/tests.js#L507). This leads me to believe that you expect this method of instantiation to work.
