### PR TITLE
Use default plural forms expression when plurals not translated.

### DIFF
--- a/jed.js
+++ b/jed.js
@@ -288,7 +288,7 @@ in order to offer easy upgrades -- jsgettext.berlios.de
           this.options.missing_key_callback(key);
         }
         res = [ null, singular_key, plural_key ];
-        return res[ getPluralFormFunc(pluralForms)( val ) + 1 ];
+        return res[ getPluralFormFunc()( val ) + 1 ];
       }
 
       res = val_list[ val_idx ];
@@ -296,7 +296,7 @@ in order to offer easy upgrades -- jsgettext.berlios.de
       // This includes empty strings on purpose
       if ( ! res  ) {
         res = [ null, singular_key, plural_key ];
-        return res[ getPluralFormFunc(pluralForms)( val ) + 1 ];
+        return res[ getPluralFormFunc()( val ) + 1 ];
       }
       return res;
     }

--- a/test/tests.js
+++ b/test/tests.js
@@ -275,6 +275,7 @@
           expect(i18n.ngettext('Not translated', 'Not translated plural', 1) ).to.be( 'Not translated' );
           expect(i18n.ngettext('Not translated', 'Not translated plural', 2) ).to.be( 'Not translated plural' );
           expect(i18n.ngettext('Not translated', 'Not translated plural', 0) ).to.be( 'Not translated plural' ); 
+          expect(i18n_2.ngettext('Not translated', 'Not translated plural', 3) ).to.be( 'Not translated plural' );
         });
 
         it("should be able to parse complex pluralization rules", function () {


### PR DESCRIPTION
Previously, if a plural were not translated, the current language's
plural forms expression would be used to select from the two msgids
passed into ngettext. When the current language had different plurals
from English, this could result in `undefined` being returned instead of
a string.

This makes the fallbacks use the default plural forms expression so that
a valid string is returned whether translated or not.
