### PR TITLE
Fixed an obscure bug that presents in Chromium 29.0.1547.65

### DIFF
--- a/jed.js
+++ b/jed.js
@@ -136,7 +136,7 @@ in order to offer easy upgrades -- jsgettext.berlios.de
     },
     fetch : function ( sArr ) {
       if ( {}.toString.call( sArr ) != '[object Array]' ) {
-        sArr = [].slice.call(arguments);
+        sArr = [].slice.call(arguments, 0);
       }
       return ( sArr && sArr.length ? Jed.sprintf : function(x){ return x; } )(
         this._i18n.dcnpgettext(this._domain, this._context, this._key, this._pkey, this._val),


### PR DESCRIPTION
When running the original code in Chromium 29.0.1547.65, I was getting:

```
 "Uncaught RangeError: Invalid array length", source: /js/jed.js (139)
```

Adding the alternate syntax with the 0 argument solves it. All tests pass.
