### PR TITLE
Add @preserve so jed.min.js can be identified

### DIFF
--- a/jed.js
+++ b/jed.js
@@ -1,8 +1,7 @@
+/**
+ * @preserve jed.js v0.5.0beta https://github.com/SlexAxton/Jed
+ */
 /*
-jed.js
-v0.5.0beta
-
-https://github.com/SlexAxton/Jed
 -----------
 A gettext compatible i18n library for modern JavaScript Applications
 


### PR DESCRIPTION
To ensure recognition in deployed project. Before it was just a piece of JS from nowhere.
