### PR TITLE
make test: Fix 'cannot find expect.js'

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -1,2 +1,2 @@
-expect = require('../node_modules/expect.js/expect');
+expect = require('expect.js');
 Jed = require('../jed');


### PR DESCRIPTION
Hi,

This fixes a problem with `make test`:

```
$ git clone git@github.com:SlexAxton/Jed.git
...
$ cd Jed
$ npm install
...
$ make test

module.js:340
    throw err;
          ^
Error: Cannot find module 'expect.js'
  ...
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/p/Code/Jed/test/common.js:1:72)
   ...
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:902:3
make: *** [test] Error 8
```

I'm afraid there is one more problem with `make test` but maybe it's better to fix that in another pull request.

Cheers, Philip
