### PR TITLE
make test: Fix mocha timeout @ 'Plural Forms Parsing should have the sam...

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -572,11 +572,15 @@
       // http://translate.sourceforge.net/wiki/l10n/pluralforms
       it("should have the same result as doing an eval on the expression for all known plural-forms.", function (){
         var pfs = ["nplurals=2; plural=(n > 1)","nplurals=2; plural=(n != 1)","nplurals=6; plural= n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5;","nplurals=1; plural=0","nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)","nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2","nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2","nplurals=4; plural= (n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != 11) ? 2 : 3","nplurals=2; plural=n > 1","nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4","nplurals=4; plural=(n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : (n > 2 && n < 20) ? 2 : 3","nplurals=2; plural= (n > 1)","nplurals=2; plural=(n%10!=1 || n%100==11)","nplurals=2; plural=n!=0","nplurals=2; plural=(n!=1)","nplurals=2; plural=(n!= 1)","nplurals=4; plural= (n==1) ? 0 : (n==2) ? 1 : (n == 3) ? 2 : 3","nplurals=2; plural=n>1;","nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2)","nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2)","nplurals=2; plural= n==1 || n%10==1 ? 0 : 1","nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)","nplurals=4; plural=(n==1 ? 0 : n==0 || ( n%100>1 && n%100<11) ? 1 : (n%100>10 && n%100<20 ) ? 2 : 3)","nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)","nplurals=2; plural=(n!=1);","nplurals=3; plural=(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2);","nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n%100==4 ? 3 : 0)","nplurals=2; plural=n != 1","nplurals=2; plural=(n>1)","nplurals=1; plural=0;"],
-            pf, pfi, i;
+            pf, pfc, pfe, pfi, i;
         for ( pfi = 0; pfi < pfs.length; pfi++ ) {
           pf = ""+pfs[ pfi ];
           for( i = 0; i < 106; i++ ){
-            expect( Jed.PF.compile( ""+pf )( i ) ).to.be( evalParse( ""+pf )( i ).plural );
+            pfc = Jed.PF.compile( ""+pf )( i );
+            pfe = evalParse( ""+pf )( i ).plural;
+            if (pfc !== pfe) {
+              throw new Error('expected ' + pfe + ' but got ' + pfc);
+            }
           }
         }
       });


### PR DESCRIPTION
Hey,

With this fix `make test` is error free!  My Mac needs 6 seconds with the current HEAD, Travis CI needs 3 seconds.  This patched version is a bit less than 1 second on my Mac, so it should be half a second on Travis CI which is way less than mocha's default timeout of 2 seconds...

expect.js's `be` and `to` functions aren't really complex but heavy enough to be more than 6x slower than a simple `!==` + `throw`.

Cheers, Philip
