### PR TITLE
Issue with Singular Translations in Uncommon Plural-Forms Rules

### DIFF
--- a/jed.js
+++ b/jed.js
@@ -222,9 +222,6 @@ in order to offer easy upgrades -- jsgettext.berlios.de
       // isn't explicitly passed in
       domain = domain || this._textdomain;
 
-      // Default the value to the singular case
-      val = typeof val == 'undefined' ? 1 : val;
-
       var fallback;
 
       // Handle special cases
@@ -258,23 +255,33 @@ in order to offer easy upgrades -- jsgettext.berlios.de
         throw new Error('No translation key found.');
       }
 
-      // Handle invalid numbers, but try casting strings for good measure
-      if ( typeof val != 'number' ) {
-        val = parseInt( val, 10 );
-
-        if ( isNaN( val ) ) {
-          throw new Error('The number that was passed in is not a number.');
-        }
-      }
-
       var key  = context ? context + Jed.context_delimiter + singular_key : singular_key,
           locale_data = this.options.locale_data,
           dict = locale_data[ domain ],
           defaultConf = (locale_data.messages || this.defaults.locale_data.messages)[""],
-          pluralForms = dict[""].plural_forms || dict[""]["Plural-Forms"] || defaultConf.plural_forms || defaultConf["Plural-Forms"],
-          val_idx = getPluralFormFunc(pluralForms)(val) + 1,
+          pluralForms = dict[""].plural_forms || dict[""]["Plural-Forms"] || dict[""]["plural-forms"] || defaultConf.plural_forms || defaultConf["Plural-Forms"] || defaultConf["plural-forms"],
           val_list,
           res;
+
+      var val_idx;
+      if (val === undefined) {
+        // No value passed in; assume singular key lookup.
+        val_idx = 1;
+
+      } else {
+        // Value has been passed in; use plural-forms calculations.
+
+        // Handle invalid numbers, but try casting strings for good measure
+        if ( typeof val != 'number' ) {
+          val = parseInt( val, 10 );
+
+          if ( isNaN( val ) ) {
+            throw new Error('The number that was passed in is not a number.');
+          }
+        }
+
+        val_idx = getPluralFormFunc(pluralForms)(val) + 1;
+      }
 
       // Throw an error if a domain isn't found
       if ( ! dict ) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -36,6 +36,18 @@
       }
     };
 
+    var locale_data3 = {
+      "some_domain" : {
+        "" : {
+          "domain"        : "some_domain",
+          "lang"          : "ar",
+          "plural-forms"  : "nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);"
+        },
+        "test" : [null, "test_translation_output3"],
+        "zero length translation" : [ null, "" ]
+      }
+    };
+
     var i18n = new Jed({
       "domain" : "messages",
       "locale_data" : locale_data
@@ -44,6 +56,11 @@
     var i18n_2 = new Jed({
       "domain" : "some_domain",
       "locale_data" : locale_data2
+    });
+
+    var i18n_3 = new Jed({
+      "domain" : "some_domain",
+      "locale_data" : locale_data3
     });
 
     // Standard shorthand function
@@ -56,6 +73,7 @@
       it("should exist", function () {
         expect( i18n ).to.be.ok();
         expect( i18n_2 ).to.be.ok();
+        expect( i18n_3 ).to.be.ok();
         expect( _ ).to.be.ok();
       });
     });
@@ -67,6 +85,10 @@
 
       it("should just pass through strings that aren't translatable", function () {
         expect( i18n.gettext('missing') ).to.be( 'missing' );
+      });
+
+      it("should translate a key in a locale with plural-forms rules that don't assume n==1 will return 0", function () {
+        expect(i18n_3.gettext('test')).to.be('test_translation_output3');
       });
 
       it("should allow you to wrap it as a shorthand function", function () {


### PR DESCRIPTION
This PR contains two changes:
- The documentation, as well as many of the tests, are inconsistent in specifying the plural forms option as `plural_forms` or `plural-forms`. I've altered the retrieval of the rules so that it looks for both cases (whereas before it was only actually looking for `plural_forms`).
- `gettext()` was failing for locales where the pluralization rules don't return `0` when given an `n` of `1`. For example, the plural forms rule for Arabic is `nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);`, which, when given an `n` of `1`, returns `1`. Since the `dcnpgettext()` function was assuming an `n` of `1` when dealing with translations of singular keys, the logic would end up looking past the end of the array specified for that key.
