### PR TITLE
Don't explicitly name the module.

### DIFF
--- a/jed.js
+++ b/jed.js
@@ -1011,7 +1011,7 @@ return parser;
   }
   else {
     if (typeof define === 'function' && define.amd) {
-      define('jed', function() {
+      define(function() {
         return Jed;
       });
     }


### PR DESCRIPTION
This allows for [greater portability](http://requirejs.org/docs/api.html#modulename), eg. I can't load Jed from a subdirectory without this change.
